### PR TITLE
NAS-118080 / 22.12 / update collectd to fix build

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 VERSION=5.12.0
-REVISION=9
+REVISION=11
 
 wget http://deb.debian.org/debian/pool/main/c/collectd/collectd_$VERSION-$REVISION.debian.tar.xz
 tar xf collectd_$VERSION-$REVISION.debian.tar.xz


### PR DESCRIPTION
Version 5.12.0-9 tarball was yanked from upstream location. Not sure if this was a mistake or by design but either way we need to update collectd to pull in latest version so the build works.