### PR TITLE
NAS-120141 / 23.10 / fix building collectd

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -1,15 +1,17 @@
 #!/bin/bash -ex
-BASEURL="https://launchpad.net/debian/+archive/primary/+sourcefiles/collectd/5.12.0-11/"
+VERSION=5.12.0
+REVISION=11
+BASEURL="https://launchpad.net/debian/+archive/primary/+sourcefiles/collectd/$VERSION-$REVISION"
 
 # download revision source
-REVISION_FILE="collectd_5.12.0-11.debian.tar.xz"
-wget $BASEURL$REVISION_FILE
+REVISION_FILE="collectd_$VERSION-$REVISION.debian.tar.xz"
+wget "$BASEURL/$REVISION_FILE"
 tar xf $REVISION_FILE
 rm $REVISION_FILE
 
 # download version source
-VERSION_FILE="collectd_5.12.0.orig.tar.xz"
-wget $BASEURL$VERSION_FILE
+VERSION_FILE="collectd_$VERSION.orig.tar.xz"
+wget "$BASEURL/$VERSION_FILE"
 tar xf $VERSION_FILE --strip 1
 rm $VERSION_FILE
 

--- a/pull.sh
+++ b/pull.sh
@@ -1,14 +1,17 @@
 #!/bin/bash -ex
-VERSION=5.12.0
-REVISION=11
+BASEURL="https://launchpad.net/debian/+archive/primary/+sourcefiles/collectd/5.12.0-11/"
 
-wget http://deb.debian.org/debian/pool/main/c/collectd/collectd_$VERSION-$REVISION.debian.tar.xz
-tar xf collectd_$VERSION-$REVISION.debian.tar.xz
-rm collectd_$VERSION-$REVISION.debian.tar.xz
+# download revision source
+REVISION_FILE="collectd_5.12.0-11.debian.tar.xz"
+wget $BASEURL$REVISION_FILE
+tar xf $REVISION_FILE
+rm $REVISION_FILE
 
-wget http://deb.debian.org/debian/pool/main/c/collectd/collectd_$VERSION.orig.tar.xz
-tar xf collectd_$VERSION.orig.tar.xz --strip 1
-rm collectd_$VERSION.orig.tar.xz
+# download version source
+VERSION_FILE="collectd_5.12.0.orig.tar.xz"
+wget $BASEURL$VERSION_FILE
+tar xf $VERSION_FILE --strip 1
+rm $VERSION_FILE
 
 cp aggregation-cpu.patch debian/patches
 echo 'aggregation-cpu.patch' >> debian/patches/series


### PR DESCRIPTION
debian has removed the compressed archive for the collectd version that we’re building from. This seems to be a common pattern that happens every 2 minor revisions. For example, this broke the same way when we were building 5.12.0-9, we had to bump to 5.12.0-11.

Now there is 5.12.0-13. This is going to keep breaking every 2 minor revisions (I predict) which is annoying. The URL that we’re using follows the latest debian release which means we have a chance of updating collectd and it failing to compile since the version we update to might not be for the debian version that we’re running.

Since we’re keeping collectd in bluefin, I’m switching to using launchpad.net URLs to download the source to, in theory, work-around all of these issues.

And yes, I did try to build 5.12.0-13 but it’s failing to compile on nuts plugin because 5.12.0-13 was added for bookworm and apparently, they reenabled the nuts plugin.